### PR TITLE
Correct field name for entity ID.

### DIFF
--- a/inc/webapplication.class.php
+++ b/inc/webapplication.class.php
@@ -277,7 +277,7 @@ class PluginWebapplicationsWebapplication extends CommonDBTM {
       $tab[] = [
          'id'                 => '81',
          'table'              => 'glpi_entities',
-         'field'              => 'entities_id',
+         'field'              => 'id',
          'name'               => __('Entity') . "-" . __('ID')
       ];
       return $tab;


### PR DESCRIPTION
'id' replaces 'entities_id' which is the parent entity.