### PR TITLE
Fix clean install on 9.5

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -176,7 +176,6 @@ function plugin_webapplications_uninstall() {
    global $DB;
 
    include_once(GLPI_ROOT . "/plugins/webapplications/inc/profile.class.php");
-   include_once(GLPI_ROOT . "/plugins/webapplications/inc/menu.class.php");
 
    $tables = ["glpi_plugin_webapplications_appliances",
               "glpi_plugin_webapplications_webapplicationtypes",
@@ -221,7 +220,6 @@ function plugin_webapplications_uninstall() {
       $profileRight->deleteByCriteria(['name' => $right['field']]);
    }
 
-   PluginWebapplicationsMenu::removeRightsFromSession();
    PluginWebapplicationsProfile::removeRightsFromSession();
 
    return true;

--- a/setup.php
+++ b/setup.php
@@ -27,7 +27,7 @@
  --------------------------------------------------------------------------
  */
 
-define('PLUGIN_WEBAPPLICATIONS_VERSION', '3.0.0');
+define('PLUGIN_WEBAPPLICATIONS_VERSION', '3.0.1');
 
 // Init the hooks of the plugins -Needed
 function plugin_init_webapplications() {

--- a/sql/empty-3.0.0.sql
+++ b/sql/empty-3.0.0.sql
@@ -14,8 +14,8 @@ CREATE TABLE `glpi_plugin_webapplications_webapplicationservertypes` (
 INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('1', 'Apache', '');
 INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('2', 'IIS', '');
 INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('3', 'Nginx', '');
-INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('3', 'PRTG', '');
-INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('3', 'Tomcat', '');
+INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('4', 'PRTG', '');
+INSERT INTO `glpi_plugin_webapplications_webapplicationservertypes` VALUES ('5', 'Tomcat', '');
 
 
 DROP TABLE IF EXISTS `glpi_plugin_webapplications_webapplicationtypes`;


### PR DESCRIPTION
Fix missing file and missing class error when referencing old menu class.
Fix duplicate primary keys in server types table.